### PR TITLE
Use latest changes from common cloud code repo

### DIFF
--- a/TestHelpers/functions.sh
+++ b/TestHelpers/functions.sh
@@ -127,7 +127,7 @@ dumpKeyAdv() {
     local url
     url="http://${ip}:${port}/${ADV_PATH}"
     local get_command1
-    get_command1="curl ${url} --connect-timeout ${TO_WGET_CONNECTION} -o ${file} 1>/dev/null 2>/dev/null"
+    get_command1="curl ${url} --connect-timeout ${TO_CURL_CONNECTION} -o ${file} 1>/dev/null 2>/dev/null"
     ocpopLogVerbose "DUMP_KEY_ADV_COMMAND:[${get_command1}]"
     ${get_command1}
 }


### PR DESCRIPTION
Due to latest changes in common-cloud-orchestration ([common-cloud-orchestration#33](https://github.com/RedHat-SP-Security/common-cloud-orchestration/pull/35)) repository, tang-operator tests should be fixed
to follow those changes