### PR TITLE
Add new environment vars for packit ci plan

### DIFF
--- a/Plans/packit-ci.fmf
+++ b/Plans/packit-ci.fmf
@@ -12,6 +12,9 @@ environment:
   TANG_IMAGE: "quay.io/sec-eng-special/fedora_tang_server"
   CI: "true"
   EXECUTION_MODE: "MINIKUBE"
+  #need to add due building operator in konflux
+  KONFLUX: "1"
+  OPERATOR_NAME: "nbde-tang-server" 
 
 discover:
   - name: Configure_test_system

--- a/Plans/upstream-operator-all-tests.fmf
+++ b/Plans/upstream-operator-all-tests.fmf
@@ -13,6 +13,10 @@ environment:
   UPSTREAM_OPERATOR: "true"
   REPO_CLONE: "tang"
   EXECUTION_MODE: "minikube"
+  V: "1"
+  #need to add due building operator in konflux
+  KONFLUX: "1"
+  OPERATOR_NAME: "nbde-tang-server"
 
 discover:
   - name: Configure_test_system


### PR DESCRIPTION
operator is now built via KONFLUX, name of running operator is different and need to be adjusted
in test suite.