### PR TITLE
Disable plan for usage

### DIFF
--- a/Plans/upstream-operator-all-tests.fmf
+++ b/Plans/upstream-operator-all-tests.fmf
@@ -1,4 +1,6 @@
 summary: Plan with installation of upstream tang operator.
+#not needed anymore, when it's tang onboarded in KONFLUX
+enabled: false
 
 
 prepare:


### PR DESCRIPTION
Plan won't be used in CI and
will be disabled due move tang-operator
to KONFLUX, it's not needed to build upstream
tang-operator image.