### PR TITLE
Update rapidast version (2.11.0->2.13.0)

### DIFF
--- a/Sanity/DAST_test/runtest.sh
+++ b/Sanity/DAST_test/runtest.sh
@@ -124,7 +124,7 @@ rlPhaseStartTest "Dynamic Application Security Testing"
     sed -i "s@kubectl --kubeconfig=./kubeconfig @${OC_CLIENT} @" helm/results.sh
     sed -i '/--for=condition=Ready/{ /--timeout/!s@wait @wait --timeout=300s @; }' helm/results.sh
     sed -i s@"secContext: '{}'"@"secContext: '{\"privileged\": true}'"@ helm/chart/values.yaml
-    sed -i s@'tag: "latest"'@'tag: "2.11.0"'@g helm/chart/values.yaml
+    sed -i s@'tag: "latest"'@'tag: "2.13.0"'@g helm/chart/values.yaml
 
     # GCS export configuration (optional, enabled by setting GCS_KEY_FILE)
     if [ -n "${GCS_KEY_FILE}" ]; then


### PR DESCRIPTION
## Summary by Sourcery

Update the DAST test script to use Rapidast image version 2.13.0 instead of 2.11.0 by adjusting the Helm chart values used during test setup.